### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Release
 run-name: '${{ github.run_id }} - Release Workflow - ${{ github.ref_name }}'
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/WarehouseFinds/PSRedFishClient/security/code-scanning/2](https://github.com/WarehouseFinds/PSRedFishClient/security/code-scanning/2)

In general, the problem is fixed by adding an explicit `permissions` block at the workflow level (top-level) or at the job level (under `jobs.build`) to restrict the `GITHUB_TOKEN` to the minimal scopes needed. Since this workflow only needs to read repository contents (for checkout and versioning) and upload artifacts (which do not use GitHub API write scopes), the minimal safe permission is `contents: read`.

The best targeted fix without changing functionality is to add a top-level `permissions` block right after the workflow `name` (or right after `run-name`). This will apply to all jobs in this workflow and satisfy CodeQL’s recommendation. Concretely, in `.github/workflows/release.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top, so that the entire workflow runs with a read-only `GITHUB_TOKEN` for repository contents. No other code changes, imports, or additional definitions are required, and no steps rely on elevated write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
