### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     name: Build and Test
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/WarehouseFinds/PSRedFishClient/security/code-scanning/1](https://github.com/WarehouseFinds/PSRedFishClient/security/code-scanning/1)

To fix this, explicitly declare the `permissions` for the `GITHUB_TOKEN` in the workflow, limiting them to the minimum needed. Since this workflow checks out code, installs modules, builds, runs tests, and uploads artifacts, it only needs read access to repository contents. None of the shown steps perform write operations against the GitHub API (like pushing commits, updating issues, or managing releases), so `contents: read` at the job or workflow level is sufficient.

The best minimal fix without changing existing functionality is to add a `permissions:` block with `contents: read` to the `build` job definition. This directly addresses the CodeQL warning (which points at the job) and avoids altering behavior of any other jobs that might exist elsewhere in the file. Concretely, in `.github/workflows/pull-request.yml`, under `jobs:`, inside the `build:` job and before `name: Build and Test` (line 11), insert:

```yaml
    permissions:
      contents: read
```

No additional imports or external methods are required; this is pure GitHub Actions YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
