### PR TITLE
Update release action to use ncipollo/release-action

### DIFF
--- a/.github/workflows/powershell-build-module.yml
+++ b/.github/workflows/powershell-build-module.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Generate release notes
         shell: pwsh
         id: generate_release_notes
-        if: github.ref_name == 'main' && github.event_name == 'workflow_dispatch'
+        if: github.ref_name == 'main' && (github.event_name == 'workflow_dispatch' || github.event_name == 'push')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -153,19 +153,29 @@ jobs:
           Write-Output  ($result.body.ToString()) >> $env:GITHUB_OUTPUT
           Write-Output  'EOF' >> $env:GITHUB_OUTPUT
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e #v1.1.4
-        if: github.ref_name == 'main' && (github.event_name == 'workflow_dispatch' || github.event_name == 'push')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #- name: Create Release
+      #  id: create_release
+      #  uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e #v1.1.4
+      #  if: github.ref_name == 'main' && (github.event_name == 'workflow_dispatch' || github.event_name == 'push')
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #  with:
+      #    tag_name: v${{ env.majorMinorPatch }}
+      #    release_name: Release v${{ env.majorMinorPatch }}
+      #    body: |
+      #      ${{ steps.generate_release_notes.outputs.releaseNotes }}
+      #    draft: false
+      #    prerelease: ${{ env.releaseType == 'Prerelease' }}
+
+      - name: Create release
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: v${{ env.majorMinorPatch }}
-          release_name: Release ${{ env.releaseVersion }}
-          body: |
-            ${{ steps.generate_release_notes.outputs.releaseNotes }}
-          draft: false
+          name: Release v${{ env.majorMinorPatch }}
+          tag: v${{ env.majorMinorPatch }}
+          body: ${{ steps.generate_release_notes.outputs.releaseNotes }}
           prerelease: ${{ env.releaseType == 'Prerelease' }}
+          allowUpdates: true
+
 
       - name: Commit generated help
         if: github.ref_name == 'main' && github.event_name == 'push'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and releasing the PowerShell module. The main focus is on improving the release process by switching to a different action for creating releases and slightly broadening the conditions under which release notes are generated.

**Release process improvements:**

* Replaced the `actions/create-release` action with the `ncipollo/release-action` for creating GitHub releases, enabling support for release updates and simplifying configuration.
* Commented out the previous `actions/create-release` step and added a new step using `ncipollo/release-action`, which allows updating existing releases and sets the release name, tag, and body.

**Workflow trigger adjustments:**

* Modified the condition for generating release notes so that it now runs on both `workflow_dispatch` and `push` events, instead of only `workflow_dispatch`.