### PR TITLE
Fix output redirection for build version in CI workflow

### DIFF
--- a/.github/workflows/powershell-script-module-build.yml
+++ b/.github/workflows/powershell-script-module-build.yml
@@ -72,7 +72,7 @@ jobs:
                   $buildVersion = $env:semVer
               }
           }
-          echo "build-version=$buildVersion" >> $env:GITHUB_OUTPUT -Append
+          echo "build-version=$buildVersion" >> $env:GITHUB_OUTPUT
 
       - name: Run build via Invoke-Build
         shell: pwsh


### PR DESCRIPTION
# Description

This pull request makes a minor update to the GitHub Actions workflow by removing the unnecessary `-Append` flag when writing the `build-version` to the workflow output. This change helps ensure compatibility and clarity in the workflow script.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Semantic Versioning

<!-- Include the appropriate keyword in your commit message to control versioning -->

- [ ] `+semver: major` - Breaking changes (1.0.0 → 2.0.0)
- [ ] `+semver: minor` - New features (1.0.0 → 1.1.0)
- [ ] `+semver: patch` - Bug fixes (1.0.0 → 1.0.1)
- [ ] `+semver: none` - No version change (documentation, tests)

## Checklist

<!-- Mark completed items with an 'x' -->

### Code Quality

- [ ] Code follows PowerShell best practices and approved verbs

### Testing

- [ ] All new functions have corresponding `.Tests.ps1` files
- [ ] New tests added for new functionality

### Documentation

- [ ] Comment-based help is complete and accurate
- [ ] Examples included in help documentation
- [ ] README.md updated (if applicable)

## Related Issues

<!-- Link related issues using #issue_number or 'Fixes #issue_number' for auto-closing -->
Fixes #issue_number

## Additional Notes

<!-- Add any additional context, screenshots, or information about the PR here -->
