### PR TITLE
Update CI workflow to include all documentation files in the path checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,19 +28,12 @@ jobs:
     runs-on: [ubuntu-latest]
     if: github.event_name == 'pull_request'
     permissions:
+      contents: read
       pull-requests: write
-      issues: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.01
-
-      - name: Execute assign PR labels
-        id: action-assign-labels
-        uses: mauroalderete/action-assign-labels@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          #conventional-commits: '.github/labeler.yml'
-          apply-changes: true
+    - name: Labeler
+      id: labeler
+      uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b #v6.0.1
 
   setup:
     name: Setup


### PR DESCRIPTION
# Description

This pull request makes a small update to the CI workflow configuration. The change broadens the documentation file path filter to include all files and subdirectories under `docs/`, ensuring that changes to any documentation file will trigger the workflow.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Checklist

<!-- Mark completed items with an 'x' -->

### Code Quality

- [ ] Code follows PowerShell best practices and approved verbs

### Testing

- [ ] All new functions have corresponding `.Tests.ps1` files
- [ ] New tests added for new functionality

### Documentation

- [ ] Examples included in help documentation
- [ ] README.md updated (if applicable)

## Related Issues

<!-- Link related issues using #issue_number or 'Fixes #issue_number' for auto-closing -->
Fixes #issue_number

## Additional Notes

<!-- Add any additional context, screenshots, or information about the PR here -->
