### PR TITLE
Add condition to check if repository is a template in get_repo_state job

### DIFF
--- a/.github/workflows/bootstrap-repo.yml
+++ b/.github/workflows/bootstrap-repo.yml
@@ -21,6 +21,7 @@ jobs:
   # Get the current step to only run the main job when the learner is on the same step.
   get_repo_state:
     name: Check current repository state
+    if: ${{ !github.event.repository.is_template }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
# Description

This pull request introduces a small change to the `.github/workflows/bootstrap-repo.yml` workflow. The update adds a conditional check to ensure the `get_repo_state` job only runs when the repository is not a template.