### PR TITLE
Remove NuGet.org publishing option from GitHub Actions workflow and clean up release step inputs

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -18,11 +18,6 @@ on:
         required: false
         type: boolean
         default: true
-      publish-nugetorg:
-        description: 'Publish release to NuGet.org'
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   setup:
@@ -61,12 +56,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    with:
-      release-type: ${{ inputs['release-type'] }}
-      release-version: ${{ needs.build.outputs.release-version }}
-      publish-psgallery: ${{ inputs.publish-psgallery }}
-      module-list: ${{ needs.setup.outputs.module-list }}
-    secrets: inherit
     steps:
       - name: Release Module
         uses: ./.github/actions/ps-release
@@ -77,7 +66,6 @@ jobs:
         with:
           release-version: ${{ needs.build.outputs.release-version }}
           publish-psgallery: ${{ inputs.publish-psgallery }}
-          publish-nugetorg: ${{ inputs.publish-nugetorg }}
           module-list: ${{ needs.setup.outputs.module-list }}
         env:
           PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}


### PR DESCRIPTION
# Description

This pull request makes some minor updates to the GitHub Actions workflow for releases. The main change is the removal of the `publish-nugetorg` input and its related configuration from the release workflow.

Key changes:

**Workflow inputs and configuration:**

* Removed the `publish-nugetorg` input parameter from the workflow, so releases will no longer have the option to publish to NuGet.org using this workflow.
* Removed references to `publish-nugetorg` from the job configuration and the step that calls the release action. [[1]](diffhunk://#diff-0888eb1fa7aab434143ff998244c8f1e3f81f96ef8dc423dc8854d87ba5bda86L64-L69) [[2]](diffhunk://#diff-0888eb1fa7aab434143ff998244c8f1e3f81f96ef8dc423dc8854d87ba5bda86L80)

## Type of Change

<!-- Select one by placing an 'x' in the brackets -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code quality improvement (refactoring, tests, performance)
