### PR TITLE
Update condition for committing generated help in action.yml

### DIFF
--- a/.github/actions/ps-build/action.yml
+++ b/.github/actions/ps-build/action.yml
@@ -85,7 +85,7 @@ runs:
         if-no-files-found: warn
 
     - name: Commit generated help
-      if: ${{ github.ref_name == 'main' && github.event_name == 'push' }}
+      if: ${{ github.ref_name != 'main' && github.event_name == 'pull_request' }}
       shell: bash
       run: |
         git add docs/help


### PR DESCRIPTION
# Description

This pull request updates the workflow logic for committing generated help documentation in the `.github/actions/ps-build/action.yml` file. The change modifies when the `Commit generated help` step runs, ensuring it only executes for pull requests on non-main branches.

* Workflow condition update:
  * The `Commit generated help` step now runs only if the branch is not `main` and the event is a `pull_request`, instead of running on pushes to the `main` branch. (`.github/actions/ps-build/action.yml`)

## Type of Change

<!-- Select one by placing an 'x' in the brackets -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code quality improvement (refactoring, tests, performance)
