### PR TITLE
Refactor VSCode tasks and launch configurations for improved build and test processes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "request": "launch",
       "name": "PowerShell Launch Current File",
       "script": "${file}",
-      "args": [],
+      "args": [ ],
       "cwd": "${file}"
     },
     {
@@ -14,7 +14,7 @@
       "request": "launch",
       "name": "PowerShell Launch Current File in Temporary Console",
       "script": "${file}",
-      "args": [],
+      "args": [ ],
       "cwd": "${file}",
       "createTemporaryIntegratedConsole": true
     },
@@ -23,30 +23,8 @@
       "request": "launch",
       "name": "PowerShell Launch Current File w/Args Prompt",
       "script": "${file}",
-      "args": ["${command:SpecifyScriptArgs}"],
+      "args": [ "${command:SpecifyScriptArgs}" ],
       "cwd": "${file}"
-    },
-    {
-      "type": "PowerShell",
-      "request": "launch",
-      "name": "PowerShell Launch DebugTest.ps1",
-      "script": "${workspaceRoot}/DebugTest.ps1",
-      "args": ["-Count 55 -DelayMilliseconds 250"],
-      "cwd": "${workspaceRoot}"
-    },
-    {
-      "type": "PowerShell",
-      "request": "launch",
-      "name": "PowerShell Interactive Session",
-      "cwd": "${workspaceRoot}"
-    },
-    {
-      "type": "PowerShell",
-      "request": "launch",
-      "name": "PowerShell Pester Tests",
-      "script": "Invoke-Pester",
-      "args": [],
-      "cwd": "${workspaceRoot}"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,24 +41,74 @@
         {
             "label": "Bootstrap",
             "type": "shell",
-            "command": "Import-Module '${workspaceFolder}/build.psm1'; Start-PSBootstrap",
-            "problemMatcher": []
+            "command": "if (-not (Get-Module -ListAvailable -Name PSDepend)) { Install-Module -Name PSDepend -Scope CurrentUser -Force }; Invoke-PSDepend -Path '${workspaceFolder}/requirements.psd1' -Install -Import -Force",
+            "problemMatcher": [ ]
         },
         {
             "label": "Clean Build",
             "type": "shell",
-            "command": "Import-Module '${workspaceFolder}/build.psm1'; Start-PSBuild -Clean -Output (Join-Path '${workspaceFolder}' debug)",
-            "problemMatcher": "$msCompile"
+            "command": "Invoke-Build Clean,Build",
+            "group": {
+                "kind": "build"
+            },
+            "problemMatcher": [ ]
         },
         {
             "label": "Build",
             "type": "shell",
-            "command": "Import-Module '${workspaceFolder}/build.psm1'; Start-PSBuild -Output (Join-Path '${workspaceFolder}' debug)",
+            "command": "Invoke-Build Build",
             "group": {
                 "kind": "build",
                 "isDefault": true
             },
-            "problemMatcher": "$msCompile"
+            "problemMatcher": [ ]
+        },
+        {
+            "label": "Test",
+            "type": "shell",
+            "command": "Invoke-Build Test",
+            "group": "test",
+            "problemMatcher": [ ]
+        },
+        {
+            "label": "UnitTests",
+            "type": "shell",
+            "command": "Invoke-Build UnitTests",
+            "group": "test",
+            "problemMatcher": [ ]
+        },
+        {
+            "label": "IntegrationTests",
+            "type": "shell",
+            "command": "Invoke-Build IntegrationTests",
+            "group": "test",
+            "problemMatcher": [ ]
+        },
+        {
+            "label": "PSScriptAnalyzer",
+            "type": "shell",
+            "command": "Invoke-Build PSScriptAnalyzer",
+            "group": "test",
+            "problemMatcher": [ ]
+        },
+        {
+            "label": "InjectionHunter",
+            "type": "shell",
+            "command": "Invoke-Build InjectionHunter",
+            "group": "test",
+            "problemMatcher": [ ]
+        },
+        {
+            "label": "Export-CommandHelp",
+            "type": "shell",
+            "command": "Invoke-Build Export-CommandHelp",
+            "problemMatcher": [ ]
+        },
+        {
+            "label": "Clean",
+            "type": "shell",
+            "command": "Invoke-Build Clean",
+            "problemMatcher": [ ]
         }
     ]
 }


### PR DESCRIPTION
# Description

This pull request updates the VS Code configuration to streamline build and test workflows and remove unused PowerShell launch configurations. The main focus is shifting build and test automation to use `Invoke-Build` tasks, improving consistency and maintainability.

**Build and Test Workflow Improvements:**

* Replaced custom PowerShell commands in `.vscode/tasks.json` with standardized `Invoke-Build` tasks for `Bootstrap`, `Clean Build`, and `Build` operations, simplifying the build process and making it easier to maintain.
* Added new tasks for `Test`, `UnitTests`, `IntegrationTests`, `PSScriptAnalyzer`, `InjectionHunter`, and `Export-CommandHelp` in `.vscode/tasks.json`, enabling easier execution of common development and QA tasks directly from VS Code.

**Configuration Cleanup:**

* Removed several PowerShell launch configurations from `.vscode/launch.json` that are no longer needed, reducing clutter and potential confusion for developers.

## Type of Change

<!-- Select one by placing an 'x' in the brackets -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Code quality improvement (refactoring, tests, performance)
