### PR TITLE
Add read permissions for contents in CI jobs (private repos)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
   dependencies:
     name: Dependencies
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       module-list: ${{ steps.resolve.outputs.module-list }}
     steps:
@@ -60,6 +62,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     permissions:
+      contents: read
       issues: write
       pull-requests: write
       checks: write
@@ -76,6 +79,7 @@ jobs:
     needs: [dependencies]
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
       pull-requests: write
       checks: write
@@ -92,6 +96,7 @@ jobs:
     needs: [dependencies]
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
       pull-requests: write
       checks: write


### PR DESCRIPTION
# Description

This pull request makes updates to the GitHub Actions workflow configuration in `.github/workflows/ci.yml` to explicitly set the `contents: read` permission for several jobs. This change clarifies and tightens the permissions required by the workflow, aligning with GitHub's best practices for security.

Workflow permissions updates:

* Added `contents: read` permission to the `dependencies` job to ensure it only has the necessary access to repository contents.
* Added `contents: read` permission to the `test` job matrix, improving security by limiting repository content access.
* Added `contents: read` permission to the `lint` job, following least-privilege principles.
* Added `contents: read` permission to the `build` job, ensuring only required permissions are granted.

## Type of Change

<!-- Select one by placing an 'x' in the brackets -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code quality improvement (refactoring, tests, performance)
