### PR TITLE
Update artifact name and path to include compiled module only

### DIFF
--- a/.github/actions/ps-build/action.yml
+++ b/.github/actions/ps-build/action.yml
@@ -80,8 +80,8 @@ runs:
       uses: actions/upload-artifact@v6
       if: (!cancelled())
       with:
-        name: build-v${{ steps.gitversion.outputs.majorMinorPatch }}
-        path: build
+        name: ${{ github.event.repository.name }}-v${{ steps.gitversion.outputs.majorMinorPatch }}
+        path: build/out/${{ github.event.repository.name }}
         if-no-files-found: warn
 
     - name: Commit generated help


### PR DESCRIPTION
# Description

This pull request updates the artifact upload step in the GitHub Actions workflow to improve artifact naming and organization. The artifact name now includes the repository name, and the upload path is more specific to the repository, which helps with clarity and prevents conflicts when handling artifacts from multiple repositories.

**Improvements to artifact handling:**

* Updated the `name` of the uploaded artifact to include the repository name, making artifacts easier to identify.
* Changed the `path` to upload artifacts from `build/out/${{ github.event.repository.name }}` instead of the generic `build` directory, ensuring artifacts are organized by repository.

## Type of Change

<!-- Select one by placing an 'x' in the brackets -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code quality improvement (refactoring, tests, performance)
