### PR TITLE
Refactor GitHub labeler configuration for cmdlets and CI/CD paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,7 +3,7 @@
 # https://github.com/actions/labeler
 
 # Path-based labels
-source:
+cmdlets:
   - changed-files:
     - any-glob-to-any-file:
       - 'src/**/*.ps1'
@@ -29,8 +29,8 @@ build:
 ci-cd:
   - changed-files:
     - any-glob-to-any-file:
-      - '.github/workflows/**/*.yml'
-      - '.github/workflows/**/*.yaml'
+      - '.github/workflows/**/*'
+      - '.github/actions/**/*'
 
 github:
   - changed-files:


### PR DESCRIPTION
# Description

This pull request updates the `.github/labeler.yml` configuration to improve labeling of pull requests based on file changes. The most important changes are grouped below:

Label naming and assignment improvements:

* Renamed the `source` label to `cmdlets` for files matching `src/**/*.ps1`, ensuring more accurate labeling for PowerShell cmdlet files.

CI/CD label coverage enhancements:

* Expanded the `ci-cd` label to include all files in `.github/workflows` and `.github/actions`, regardless of file extension, improving coverage for workflow and action files.

## Type of Change

<!-- Select one by placing an 'x' in the brackets -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code quality improvement (refactoring, tests, performance)
