### PR TITLE
Update onCreateCommand to use PSDepend

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -74,7 +74,7 @@
     },
 
     // Run once when the container is created
-    "onCreateCommand": "pwsh -NoProfile -Command 'Install-PSResource -RequiredResourceFile /workspaces/PSScriptModule/requirements.psd1 -AcceptLicense -TrustRepository -Verbose'",
+    "onCreateCommand": "pwsh -NoProfile -Command \"if (-not (Get-Module -ListAvailable -Name PSDepend)) { Install-Module -Name PSDepend -Scope CurrentUser -Force }; Invoke-PSDepend -Path '/workspaces/PSScriptModule/requirements.psd1' -Install -Import -Force -Verbose\"",
 
     // Run after container starts (each time)
     "postStartCommand": "pwsh -NoProfile -Command 'Write-Host \"Container started.\"'",


### PR DESCRIPTION
# Description

This pull request updates the container initialization process in `.devcontainer/devcontainer.json` to improve dependency management. Instead of using `Install-PSResource`, it now ensures the `PSDepend` module is installed and uses it to handle dependencies as specified in `requirements.psd1`.

Dependency management improvements:

* Updated the `onCreateCommand` to check for and install the `PSDepend` module if it's not already available, then uses `Invoke-PSDepend` to install and import dependencies from `requirements.psd1` with improved reliability and verbosity.

## Type of Change

<!-- Select one by placing an 'x' in the brackets -->
- [ x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code quality improvement (refactoring, tests, performance)
